### PR TITLE
Small rename for launcher. s/SauceLab/SauceLabs/g

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var SauceConnect = function(emitter, logger) {
 };
 
 
-var SauceLabBrowser = function(id, args, sauceConnect, /* config.sauceLabs */ config, logger) {
+var SauceLabsBrowser = function(id, args, sauceConnect, /* config.sauceLabs */ config, logger) {
   config = config || {};
 
   var username = process.env.SAUCE_USERNAME || args.username || config.username;
@@ -129,5 +129,5 @@ var SauceLabBrowser = function(id, args, sauceConnect, /* config.sauceLabs */ co
 // PUBLISH DI MODULE
 module.exports = {
   'sauceConnect': ['type', SauceConnect],
-  'launcher:SauceLabs': ['type', SauceLabBrowser]
+  'launcher:SauceLabs': ['type', SauceLabsBrowser]
 };


### PR DESCRIPTION
SauceLab may confuse people as we are naming things SauceLabs everywhere else. Not sure if this affects users' config.
