### PR TITLE
[Fixes #5] Process never dies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var SauceConnect = function(emitter, logger) {
     alreadyRunningDefered = q.defer();
     launchSauceConnect(options, function(err, p) {
       if (onKilled) {
-        return onKilled();
+        return;
       }
 
       alreadyRunningProces = p;
@@ -48,6 +48,7 @@ var SauceConnect = function(emitter, logger) {
       log.info('Shutting down Sauce Connect');
       onKilled = done;
       alreadyRunningProces.close();
+      done();
     } else {
       done();
     }


### PR DESCRIPTION
If the process finishes because all tests are done and it is executed in singleRun mode, the `launchSauceConnect` function is never called and onKilled is never executed.
