### PR TITLE
Add a 'saucelabs' reporter to report pass/fail status.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "wd": "~0.1.5",
     "sauce-connect-launcher": "~0.1.10",
-    "q": "~0.9.6"
+    "q": "~0.9.6",
+    "saucelabs": "~0.1.0"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
Add a new reporter to report pass/fail status for each browser on SauceLabs (see #10) .

To enable this, add 'saucelabs' to the reporters in the config file.

The only change to the actual launcher is to expose the job ID's and credentials to the reporter.
