### PR TITLE
(feat): Enable ability to pass custom capabilities to sauce browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,14 @@ var SauceLabsBrowser = function(id, args, sauceConnect, /* config.sauceLabs */ c
 
     };
 
+    // Adding any other option that was specified in args, but not consumed from above
+    // Useful for supplying chromeOptions, firefoxProfile, etc.
+    for (var key in args){
+      if (typeof options[key] === 'undefined') {
+        options[key] = args[key];
+      }
+    }
+
     url = url + '?id=' + id;
 
     driver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);


### PR DESCRIPTION
Added the ability to pass custom options to saucelabs. 

Example use case - 

```
 customLaunchers: {
            sl_chrome: {
                base: 'SauceLabs',
                browserName: 'chrome',
                chromeOptions: {
                    args: ['--enable-gpu-benchmarking', '--start-maximized', '--enable-thread-composting']
                },
                'disable-popup-handler': true
            },
            sl_firefox: {
                base: 'SauceLabs',
                browserName: 'firefox',
                firefox_profile: fp.encodedSync(),
                'disable-popup-handler': true
            }
```

The firefox profile is initialized using [firefox-profile](http://github.com/axemclion/firefox-profile-js)

```
var FirefoxProfile = require('firefox-profile');
    var fp = new FirefoxProfile();
    fp.setPreference('dom.send_after_paint_to_content', true);
    fp.setPreference('dom.disable_open_during_load', false);
    fp.setPreference('dom.disable_open_during_load', false);
    fp.updatePreferences();
```
