### PR TITLE
fix(wd): get sessionId from driver instead of promise resolution

### DIFF
--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -88,14 +88,14 @@ var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, 
     driver
       .init(options)
       .then(
-        function(jobId) {
+        function() {
           if (pendingCancellations > 0) {
             pendingCancellations--;
             return;
           }
           // Record the job details, so we can access it later with the reporter
           jobMapping[self.id] = {
-            jobId: jobId,
+            jobId: driver.sessionID,
             credentials: {
               username: username,
               password: accessKey


### PR DESCRIPTION
The sauce reporter is not working (I guess for a while now) because the sauce launcher is not storing the jobId correctly. Since the `init` callback in `wd` has two parameters (`sessionID` and `capabilities`), the promise resolution is actually an array of two arguments, so the `jobId` is actually `args[0]`, but I thought it would be better to just use `driver.sessionID`.
