### PR TITLE
fix: avoid failrues on error message formatting

### DIFF
--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -48,7 +48,7 @@ var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, 
   this.name = browserName + ' on SauceLabs';
 
   var formatSauceError = function(err) {
-    return err.message + '\n' + (err.data ? '  ' + err.data.split('\n').shift() : '');
+    return err.message + '\n' + (err.data ? '  ' + err.data : '');
   };
 
   var pendingHeartBeat;


### PR DESCRIPTION
Fixes #46

So, I _relly_ don't know what is the format of errors we can get from Sauce / WebDriver and how many format we should support but as noted in #46 the current formatting routine can break on certain errors.

My take here is that it is better to to have ugly formatting of error messages and actually see what gets returned from WD / Sauce than try to have nice messages that can cause build failures from time to time.

If anyone has reference / documentation of the possible error formats I would be happy to send another PR with tests.
