### PR TITLE
make disconnected builds make as fail in Sauce

### DIFF
--- a/lib/sauce_reporter.js
+++ b/lib/sauce_reporter.js
@@ -16,6 +16,13 @@ var SauceReporter = function(baseReporterDecorator, logger, /* sauce:jobMapping 
     // browser.launchId was used until v0.10.2, but changed to just browser.id in v0.11.0
     var browserId = browser.launchId || browser.id;
 
+    if(result.disconnected) {
+      log.error('✖ Test Disconnected');
+    }
+    if(result.error) {
+      log.error('✖ Test Errored');
+    }
+
     if(browserId in jobMapping) {
       var jobDetails = jobMapping[browserId];
 

--- a/lib/sauce_reporter.js
+++ b/lib/sauce_reporter.js
@@ -23,7 +23,7 @@ var SauceReporter = function(baseReporterDecorator, logger, /* sauce:jobMapping 
 
       // We record pass/fail status, as well as the full results in "custom-data".
       var payload = {
-        passed: !(result.failed || result.error),
+        passed: !(result.failed || result.error || result.disconnected),
         'custom-data': result
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sauce-launcher",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A Karma plugin. Launch any browser on SauceLabs!",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,18 +39,19 @@
   "contributors": [
     "Chris Wren <chris@saucelabs.com>",
     "Chris Wren <cthewren@gmail.com>",
-    "Pawel Kozlowski <pkozlowski.opensource@gmail.com>",
-    "Ralf Kistner <ralf@embarkmobile.com>",
-    "Santiago Suarez Ordoñez <santiycr@gmail.com>",
-    "Caitlin Potter <caitpotter88@gmail.com>",
     "Chris Wren <chriswrendev@gmail.com>",
+    "Ralf Kistner <ralf@embarkmobile.com>",
+    "Pawel Kozlowski <pkozlowski.opensource@gmail.com>",
+    "Santiago Suarez Ordoñez <santiycr@gmail.com>",
+    "Shahar Talmi <shahar.talmi@gmail.com>",
+    "sebv <seb.vincent@gmail.com>",
+    "Caitlin Potter <caitpotter88@gmail.com>",
+    "yhwh <ferrero.nicolas@gmail.com>",
     "Johannes Würbach <johannes.wuerbach@googlemail.com>",
     "Johannes Würbach <johannes.wuerbach@googlemail.com>",
     "OniOni <mathieu.c.sabourin@gmail.com>",
     "Parashuram <code@nparashuram.com>",
     "Parashuram N <code@r.nparashuram.com>",
-    "Shahar Talmi <shahar.talmi@gmail.com>",
-    "sebv <seb.vincent@gmail.com>",
-    "yhwh <ferrero.nicolas@gmail.com>"
+    "Sahat Yalkabov <sakhat@gmail.com>"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "OniOni <mathieu.c.sabourin@gmail.com>",
     "Parashuram <code@nparashuram.com>",
     "Parashuram N <code@r.nparashuram.com>",
-    "Sahat Yalkabov <sakhat@gmail.com>"
+    "Sahat Yalkabov <sakhat@gmail.com>",
+    "Joe Taylor <joetaylor@squareup.com>"
   ]
 }


### PR DESCRIPTION
This will make disconnected builds fail in sauce.

Currently if karma disconnects it still shows pass.