### PR TITLE
feat(config): support job visibility definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If `true`, Sauce Connect will be started automatically. Set this to `false` if y
 
 ### connectOptions
 Type: `Object`
-Default: 
+Default:
 ```js
 {
   username:, 'yourUsername',
@@ -146,6 +146,11 @@ Type: `Boolean`
 Default: `true`
 
 Set to `false` if you don't want to record screenshots.
+
+### public
+Type: `String`
+
+Control who can view job details. Available visibility levels are documented on the [SauceLabs website](https://docs.saucelabs.com/reference/test-configuration/#job-visibility).
 
 ## `customLaunchers` config properties
 

--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -78,7 +78,8 @@ var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, 
               process.env.BUILD_NUMBER || process.env.BUILD_TAG ||
               process.env.CIRCLE_BUILD_NUM || null,
       'device-orientation': args.deviceOrientation || null,
-      'disable-popup-handler': true
+      'disable-popup-handler': true,
+      'public': args.public || config.public || null
     });
 
     // Adding any other option that was specified in args, but not consumed from above


### PR DESCRIPTION
It is desirable for open source projects to publish their test results.
SauceLabs' API supports job visibility configuration through a
'public' parameter that can be set to one of the following:

 - public
 - public restricted
 - share
 - team (default)
 - private

The karma-sauce-launcher should support visibility configuration via
configuration options and command line arguments.