### PR TITLE
Add support for sending custom Firefox Profiles to Sauce Labs

### DIFF
--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -1,4 +1,5 @@
 var wd = require('wd');
+var FirefoxProfile = require('firefox-profile');
 
 var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, logger, helper,
     baseLauncherDecorator, captureTimeoutLauncherDecorator, retryLauncherDecorator,
@@ -64,31 +65,7 @@ var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, 
     }, 60000);
   };
 
-  var start = function(url) {
-    var options = helper.merge(config.options, args, {
-      browserName: args.browserName,
-      version: args.version || '',
-      platform: args.platform || 'ANY',
-      tags: args.tags || config.tags || [],
-      name: args.testName || config.testName || 'Karma test',
-      'tunnel-identifier': tunnelIdentifier,
-      'record-video': args.recordVideo || config.recordVideo || false,
-      'record-screenshots': (args.recordScreenshots === false || config.recordScreenshots === false) ? false : true,
-      'build': args.build || config.build || process.env.TRAVIS_BUILD_NUMBER ||
-              process.env.BUILD_NUMBER || process.env.BUILD_TAG ||
-              process.env.CIRCLE_BUILD_NUM || null,
-      'device-orientation': args.deviceOrientation || null,
-      'disable-popup-handler': true
-    });
-
-    // Adding any other option that was specified in args, but not consumed from above
-    // Useful for supplying chromeOptions, firefoxProfile, etc.
-    for (var key in args){
-      if (typeof options[key] === 'undefined') {
-        options[key] = args[key];
-      }
-    }
-
+  var initDriver = function (url, options) {
     driver
       .init(options)
       .then(
@@ -123,6 +100,50 @@ var SauceLauncher = function(args, sauceConnect, /* config.sauceLabs */ config, 
           return self._done('failure');
         }
       ).done();
+  };
+
+  var start = function(url) {
+    var options = helper.merge(config.options, args, {
+      browserName: args.browserName,
+      version: args.version || '',
+      platform: args.platform || 'ANY',
+      tags: args.tags || config.tags || [],
+      name: args.testName || config.testName || 'Karma test',
+      'tunnel-identifier': tunnelIdentifier,
+      'record-video': args.recordVideo || config.recordVideo || false,
+      'record-screenshots': (args.recordScreenshots === false || config.recordScreenshots === false) ? false : true,
+      'build': args.build || config.build || process.env.TRAVIS_BUILD_NUMBER ||
+              process.env.BUILD_NUMBER || process.env.BUILD_TAG ||
+              process.env.CIRCLE_BUILD_NUM || null,
+      'device-orientation': args.deviceOrientation || null,
+      'disable-popup-handler': true
+    });
+
+
+    // Adding any other option that was specified in args, but not consumed from above
+    // Useful for supplying chromeOptions, firefoxProfile, etc.
+    for (var key in args){
+      if (typeof options[key] === 'undefined') {
+        options[key] = args[key];
+      }
+    }
+
+    if (options.firefox_profile) {
+      var fp = new FirefoxProfile();
+
+      for (var k in options.firefox_profile) {
+        fp.setPreference(k, options.firefox_profile[k]);
+      }
+
+      fp.encoded(function (profile) {
+        options.firefox_profile = profile;
+        initDriver(url, options);
+      });
+
+    } else {
+      initDriver(url, options);
+    }
+
   };
 
   this.on('start', function(url) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "wd": "~0.3.4",
     "sauce-connect-launcher": "~0.6.0",
     "q": "~0.9.6",
-    "saucelabs": "~0.1.0"
+    "saucelabs": "~0.1.0",
+    "firefox-profile": "~0.3.6"
   },
   "peerDependencies": {
     "karma": ">=0.11.11"


### PR DESCRIPTION
Suggestion for adding support for custom firefox profiles. I am not sure the best way to add this feature, so please let me know.  

The diff got a little messy because I had to move the driver code around.  Let me know if you would like me to do this in a different way. 

This Pull Request addresss https://github.com/karma-runner/karma-sauce-launcher/issues/59

Thanks
