### PR TITLE
Add BUILD_NUMBER Compatibility For Drone And Other CI Systems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,13 @@ Options to send to Sauce Connect. Check [here](https://github.com/bermi/sauce-co
 ### build
 Type: `String`
 Default: *One of the following environment variables*:
-`process.env.TRAVIS_BUILD_NUMBER`
 `process.env.BUILD_NUMBER`
 `process.env.BUILD_TAG`
+`process.env.CI_BUILD_NUMBER`
+`process.env.CI_BUILD_TAG`
+`process.env.TRAVIS_BUILD_NUMBER`
 `process.env.CIRCLE_BUILD_NUM`
+`process.env.DRONE_BUILD_NUMBER`
 
 ID of the build currently running. This should be set by your CI.
 

--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -27,10 +27,13 @@ function processConfig (helper, config, args) {
     tunnelIdentifier: tunnelIdentifier
   })
 
-  var build = process.env.TRAVIS_BUILD_NUMBER ||
-        process.env.BUILD_NUMBER ||
+  var build = process.env.BUILD_NUMBER ||
         process.env.BUILD_TAG ||
-        process.env.CIRCLE_BUILD_NUM
+        process.env.CI_BUILD_NUMBER ||
+        process.env.CI_BUILD_TAG ||
+        process.env.TRAVIS_BUILD_NUMBER ||
+        process.env.CIRCLE_BUILD_NUM ||
+        process.env.DRONE_BUILD_NUMBER
 
   var defaults = {
     version: '',


### PR DESCRIPTION
This PR adds more CI generic env vars and resolves #82.  