### PR TITLE
feat: adding parent tunnel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Default:
 
 Options to send to Sauce Connect. Check [here](https://github.com/bermi/sauce-connect-launcher#advanced-usage) for all available options.
 
+If the option parentTunnel has been set, SauceConnect won't be started. The property will be added to the desired capabilities
+
 ### build
 Type: `String`
 Default: *One of the following environment variables*:
@@ -136,6 +138,12 @@ Name of the unit test group you are running.
 Type: `String`
 
 Sauce Connect can proxy multiple sessions, this is an id of a session.
+
+### parentTunnel
+Type: `String`
+
+If parentTunnel is set, startConnect is implicitly set to false, tunnelIdentifier won't be set.
+How to create a parentTunnel on the [SauceLabs website](https://support.saucelabs.com/customer/portal/articles/2005364-sharing-the-parent-account-tunnel)
 
 ### tags
 Type: `Array of Strings`

--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -10,22 +10,32 @@ function processConfig (helper, config, args) {
 
   var username = args.username || config.username || process.env.SAUCE_USERNAME
   var accessKey = args.accessKey || config.accessKey || process.env.SAUCE_ACCESS_KEY
-  var startConnect = config.startConnect !== false
+  // if a parent tunnel has been specified, set the startConnect to false
+  var parentTunnel = config.parentTunnel || process.env.SAUCE_PARENT_TUNNEL
+  var startConnect = (!parentTunnel) ? config.startConnect !== false : false
+
   var tunnelIdentifier = args.tunnelIdentifier || config.tunnelIdentifier
 
-  if (startConnect && !tunnelIdentifier) {
+  if (startConnect && !tunnelIdentifier && !parentTunnel) {
     tunnelIdentifier = 'karma' + Math.round(new Date().getTime() / 1000)
   }
 
   var browserName = args.browserName +
-        (args.version ? ' ' + args.version : '') +
-        (args.platform ? ' (' + args.platform + ')' : '')
+    (args.version ? ' ' + args.version : '') +
+    (args.platform ? ' (' + args.platform + ')' : '')
 
-  var connectOptions = helper.merge(config.connectOptions, {
+  var opts = {
     username: username,
-    accessKey: accessKey,
-    tunnelIdentifier: tunnelIdentifier
-  })
+    accessKey: accessKey
+  }
+
+  if (parentTunnel) {
+    opts.parentTunnel = parentTunnel
+  } else {
+    opts.tunnelIdentifier = tunnelIdentifier
+  }
+
+  var connectOptions = helper.merge(config.connectOptions, opts)
 
   var build = process.env.BUILD_NUMBER ||
         process.env.BUILD_TAG ||
@@ -40,7 +50,6 @@ function processConfig (helper, config, args) {
     platform: 'ANY',
     tags: [],
     name: 'Karma Test',
-    'tunnel-identifier': tunnelIdentifier,
     'record-video': false,
     'record-screenshots': false,
     'device-orientation': null,
@@ -100,6 +109,15 @@ var SauceLauncher = function (
   var username = pConfig.username
   var accessKey = pConfig.accessKey
   var startConnect = pConfig.startConnect
+
+  if (connectOptions.parentTunnel) {
+    options.parentTunnel = connectOptions.parentTunnel
+  } else {
+    options.tunnelIdentifier = connectOptions.tunnelIdentifier
+  }
+
+  options.username = connectOptions.username
+  options.accessKey = connectOptions.accessKey
 
   var pendingCancellations = 0
   var sessionIsReady = false
@@ -186,7 +204,7 @@ var SauceLauncher = function (
       return
     }
 
-    if (startConnect) {
+    if (startConnect && !options.parentTunnel) {
       sauceConnect.start(connectOptions)
         .then(function () {
           if (pendingCancellations > 0) {


### PR DESCRIPTION
- parentTunnel capability set in connectOptions object

- if parenTunnel is set, set start connect to false, do not start sc

- avoid duplication of the setting in each browser capabilities definition

- add socumentation