### PR TITLE
Add proxy property to config to assist with Sauce REST API connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Default: `process.env.SAUCE_ACCESS_KEY`
 
 Your Sauce Labs access key which you will see on your [account page](https://saucelabs.com/account).
 
+### proxy
+Type: `String`
+
+Proxy for connecting to Sauce REST API, which is used to communicate job updates of pass/fail.
+
 ### startConnect
 Type: `Boolean`
 Default: `true`

--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -10,6 +10,7 @@ function processConfig (helper, config, args) {
 
   var username = args.username || config.username || process.env.SAUCE_USERNAME
   var accessKey = args.accessKey || config.accessKey || process.env.SAUCE_ACCESS_KEY
+  var proxy = args.proxy || config.proxy
   var startConnect = config.startConnect !== false
   var tunnelIdentifier = args.tunnelIdentifier || config.tunnelIdentifier
 
@@ -76,6 +77,7 @@ function processConfig (helper, config, args) {
     browserName: browserName,
     username: username,
     accessKey: accessKey,
+    proxy: proxy,
     startConnect: startConnect
   }
 }
@@ -99,6 +101,7 @@ var SauceLauncher = function (
   var browserName = pConfig.browserName
   var username = pConfig.username
   var accessKey = pConfig.accessKey
+  var proxy = pConfig.proxy
   var startConnect = pConfig.startConnect
 
   var pendingCancellations = 0
@@ -155,7 +158,8 @@ var SauceLauncher = function (
           credentials: {
             username: username,
             password: accessKey
-          }
+          },
+          proxy: proxy
         }
 
         sessionIsReady = true

--- a/lib/sauce_reporter.js
+++ b/lib/sauce_reporter.js
@@ -27,7 +27,12 @@ var SauceReporter = function (logger, /* sauce:jobMapping */ jobMapping) {
     if (browserId in jobMapping) {
       var jobDetails = jobMapping[browserId]
 
-      var sauceApi = new SauceLabs(jobDetails.credentials)
+      var sauceApiOptions = jobDetails.credentials
+      if (jobDetails.proxy) {
+        sauceApiOptions.proxy = jobDetails.proxy
+      }
+
+      var sauceApi = new SauceLabs(sauceApiOptions)
 
       // We record pass/fail status, as well as the full results in "custom-data".
       var payload = {


### PR DESCRIPTION
I recently ran into an issue where the job update to sauce labs via the REST API module was hanging due to running our software behind a proxy.  The sauce labs  REST API module allows for specifying a proxy within the constructor, but it did not appear karma-sauce-launcher provided a property within the configuration to specify this attribute and pass it into that module's constructor.  So, I added the property to the config to specify the proxy, so our job update calls were successful.
