### PR TITLE
Allow SE traffic to be sent via Sauce Connect's Relay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Default:
 
 Options to send to Sauce Connect. Check [here](https://github.com/bermi/sauce-connect-launcher#advanced-usage) for all available options.
 
+### connectLocationForSERelay
+Type: `String`
+default: `ondemand.saucelabs.com`
+
+If set, will attempt to connect to the specified host as a Selenium relay.  This is intended to send Selenium commands through a Sauce Connect tunnel.
+
+### connectPortForSERelay
+Type: `Integer`
+Default: 80
+
+If set, will change the host used to connect to the Selenium server. This is intended to send Selenium commands through a Sauce Connect tunnel.
+
+
 ### build
 Type: `String`
 Default: *One of the following environment variables*:

--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -27,6 +27,9 @@ function processConfig (helper, config, args) {
     tunnelIdentifier: tunnelIdentifier
   })
 
+  var seleniumHostLocation = config.connectLocationForSERelay || 'ondemand.saucelabs.com'
+  var seleniumHostPort = config.connectPortForSERelay || connectOptions.port || 80
+
   var build = process.env.BUILD_NUMBER ||
         process.env.BUILD_TAG ||
         process.env.CI_BUILD_NUMBER ||
@@ -76,7 +79,9 @@ function processConfig (helper, config, args) {
     browserName: browserName,
     username: username,
     accessKey: accessKey,
-    startConnect: startConnect
+    startConnect: startConnect,
+    seleniumHost: seleniumHostLocation,
+    seleniumPort: seleniumHostPort
   }
 }
 
@@ -100,6 +105,8 @@ var SauceLauncher = function (
   var username = pConfig.username
   var accessKey = pConfig.accessKey
   var startConnect = pConfig.startConnect
+  var seleniumHost = pConfig.seleniumHost
+  var seleniumPort = pConfig.seleniumPort
 
   var pendingCancellations = 0
   var sessionIsReady = false
@@ -111,7 +118,7 @@ var SauceLauncher = function (
   var log = logger.create('launcher.sauce')
   var driverLog = logger.create('wd')
 
-  var driver = wd.promiseChainRemote('ondemand.saucelabs.com', 80, username, accessKey)
+  var driver = wd.promiseChainRemote(seleniumHost, seleniumPort, username, accessKey)
 
   driver.on('status', function (info) {
     driverLog.debug(info.cyan)


### PR DESCRIPTION
Tests with Sauce Connect have two connections to Sauce Labs, a
tunnel from Sauce Connect client to host, and Selenium commands themselves which are sent independently.

Sauce Connect is able to relay Selenium commands through the established tunnel, which helps obviate proxy and other issues with Selenium traffic.

This change adds config values `connectLocationForSERelay` and
`connectPortForSERelay` which allow users to make Karma send Selenium
commands through a Sauce Connect instance at that host and port.