### PR TITLE
Heartbeat fails when session has already finish.

### DIFF
--- a/lib/sauce_launcher.js
+++ b/lib/sauce_launcher.js
@@ -148,10 +148,13 @@ var SauceLauncher = function (
 
       driver.title()
         .then(null, function (err) {
-          log.error('Heartbeat to %s failed\n  %s', browserName, formatSauceError(err))
-
           clearTimeout(pendingHeartBeat)
-          return self._done('failure')
+          if (err.data.indexOf('has already finished') === -1) {
+            log.error('Heartbeat to %s failed\n  %s', browserName, formatSauceError(err))
+
+            return self._done('failure')
+          }
+          return self._done()
         })
 
       heartbeat()


### PR DESCRIPTION
Fixes #136 

Sometimes, the heartbeat timeout is not clear correctly and flags the test as failed when it is successful. This PR adds a check for session status.