### PR TITLE
Call launcher done callback

### DIFF
--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -97,6 +97,7 @@ export function SaucelabsLauncher(args,
     // Reset connected drivers in case the launcher will be reused.
     connectedDrivers = [];
 
+    this._done();
     doneFn();
   })
 }


### PR DESCRIPTION
Ensure that the launcher's `_done` callback is called on kill event.

fixes #159 