### PR TITLE
chore(semantic-release): Configure semantic-release for Travis push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ script:
   - yarn
   - yarn run-example
 
+after_success:
+  # run automated release process with semantic-release
+  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_NODE_VERSION" == "12" ]]; then
+      npm i --no-save semantic-release@15 @semantic-release/changelog@3 @semantic-release/git@7;
+      semantic-release;
+    fi;
+
 cache:
   yarn: true
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sauce-launcher",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "A Karma plugin. Launch any browser on SauceLabs!",
   "main": "./index.js",
   "scripts": {

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  debug: true,
+  branches: 'master',
+  verifyConditions: [
+    '@semantic-release/changelog',
+    '@semantic-release/github'
+  ],
+  prepare: [
+    '@semantic-release/changelog',
+    '@semantic-release/git'
+  ],
+  publish: [
+    '@semantic-release/github'
+  ],
+  success: [
+    '@semantic-release/github'
+  ]
+}


### PR DESCRIPTION
Executes `semantic-release` on Travis push builds of `master`.

Reference commit: https://github.com/karma-runner/karma-jasmine/commit/9b6e5f8987db4549ef8eeb95d89917ed10d736a6

Addresses #176 

Do not submit until https://github.com/karma-runner/karma-sauce-launcher/pull/177 is in place.