### PR TITLE
chore(semantic-release): update node version check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 
 after_success:
   # run automated release process with semantic-release
-  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_NODE_VERSION" == "12" ]]; then
+  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_NODE_VERSION" == "stable" ]]; then
       npm i --no-save semantic-release@15 @semantic-release/changelog@3 @semantic-release/git@7;
       semantic-release;
     fi;


### PR DESCRIPTION
The previous semantic-release PR failed because `TRAVIS_NODE_VERSION` was `stable`, not `12`. This PR fixes that check in the semantic-release Travis command (error due to copying the config from the other repo)