### PR TITLE
chore(node): drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
-node_js: stable
+node_js:
+  - "10.19.0"
+  - stable
 
 cache:
   yarn: true
@@ -10,7 +12,7 @@ notifications:
 script: yarn run-example
 after_success:
   # run automated release process with semantic-release
-  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push"]]; then
+  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_NODE_VERSION" == "stable"]]; then
       npm i --no-save semantic-release@15 @semantic-release/changelog@3 @semantic-release/git@7;
       semantic-release;
     fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,19 @@
 sudo: false
-
 language: node_js
-
 node_js: stable
 
-install: yarn --ignore-engines --frozen-lockfile
+cache:
+  yarn: true
+notifications:
+  email: false
 
-script:
-  - yarn
-  - yarn run-example
-
+script: yarn run-example
 after_success:
   # run automated release process with semantic-release
   - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push"]]; then
       npm i --no-save semantic-release@15 @semantic-release/changelog@3 @semantic-release/git@7;
       semantic-release;
     fi;
-
-cache:
-  yarn: true
-
-notifications:
-  email: false
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ sudo: false
 
 language: node_js
 
-node_js:
-  - "8.9.0"
-  - stable
+node_js: stable
 
 install: yarn --ignore-engines --frozen-lockfile
 
@@ -14,7 +12,7 @@ script:
 
 after_success:
   # run automated release process with semantic-release
-  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_NODE_VERSION" == "stable" ]]; then
+  - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push"]]; then
       npm i --no-save semantic-release@15 @semantic-release/changelog@3 @semantic-release/git@7;
       semantic-release;
     fi;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/karma-runner/karma-sauce-launcher.git"
   },
   "engines": {
-    "node": ">= 8.9.0"
+    "node": ">= 10.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
BREAKING CHANGE:  This PR eliminates the Node 8 runtime from package.json and the related Travis jobs/configuration.