### PR TITLE
chore(release): force-trigger a semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-sauce-launcher",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Karma plugin. Launch any browser on SauceLabs!",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE:
  Drop support for Node <10.