### PR TITLE
Add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "copy-dist-to-modules": "rm -rf node_modules/karma-sauce-launcher && mv dist/ node_modules/karma-sauce-launcher",
     "run-example-karma": "yarn karma start examples/karma.conf-ci.js"
   },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/karma-runner/karma-sauce-launcher.git"


### PR DESCRIPTION
Fixes https://github.com/karma-runner/karma-sauce-launcher/issues/190#issuecomment-606169070

Docs: https://docs.npmjs.com/files/package.json#files

> Files included with the “package.json#files” field cannot be excluded through .npmignore or .gitignore.

As a nice side-effect, no unnecessary files will be published and users' `node_modules` folder will be smaller.

![image](https://user-images.githubusercontent.com/6059356/77949193-3454f080-72cf-11ea-8298-3dc1a86decb8.png)
