### PR TITLE
docs(readme): fix Sauce Connect options link

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Proxy for connecting to Sauce REST API, which is used to communicate job updates
 Type: `Boolean`
 Default: `true`
 
-If `true`, Sauce Connect will be started automatically. Set this to `false` if you are launching tests locally and want to start Sauce Connect via [a binary](https://saucelabs.com/docs/connect) or the [Mac](https://saucelabs.com/mac) app in the background to improve test speed.
+If `true`, Sauce Connect will be started automatically.  
+Set this to `false` if you are launching tests locally but want to start Sauce Connect via [a binary](https://wiki.saucelabs.com/display/DOCS/Downloading+Sauce+Connect+Proxy) manually in the background to improve test speed.
 
 ### connectOptions
 Type: `Object`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ Default:
 }
 ```
 
-Options to send to Sauce Connect. Check [here](https://github.com/bermi/sauce-connect-launcher#advanced-usage) for all available options.
+Options to send to Sauce Connect. 
+
+Check [here](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+Command-Line+Quick+Reference+Guide) for all available options.  
+All parameters have to be applied camel cased instead of with hyphens.
 
 ### build
 Type: `String`


### PR DESCRIPTION
Currently bermi's sauce-connect-launcher options is referenced but karma-sauce-launcher is now using Sauce Labs' own node-saucelabs to start the Sauce Connect tunnel.