### PR TITLE
feat: add test annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 sauce_connect.log
 npm-debug.log
 dist/
+
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,9 +1575,9 @@
       }
     },
     "arch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
-      "integrity": "sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
     },
     "archive-type": {
       "version": "4.0.0",
@@ -2232,7 +2232,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -2493,6 +2494,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
       "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -2965,7 +2967,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -3581,6 +3584,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -10440,7 +10448,8 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -10576,17 +10585,63 @@
       "dev": true
     },
     "saucelabs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.0.tgz",
-      "integrity": "sha512-xPMYLLOJMnWRunZKiu92h4cKCR/SCTYBIvAHTlHYtDA09oebnwEOf7cjrv/+R0TuXgSYO85pll0mOXDIKUTB3Q==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-4.5.1.tgz",
+      "integrity": "sha512-413cxGr0SlYi6jTvtHth8uTRFiPQ3F3dhr3Tjwh4OT1RVxLZ+QTZSyKDtAmMinXNJrGe2BULJjt+A5n1w10uUw==",
       "requires": {
         "bin-wrapper": "^4.1.0",
         "change-case": "^4.1.1",
         "form-data": "^3.0.0",
-        "got": "^11.1.4",
+        "got": "^11.7.0",
         "hash.js": "^1.1.7",
         "tunnel": "0.0.6",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz",
+          "integrity": "sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+        },
+        "yargs": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.0.tgz",
+          "integrity": "sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.2",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+          "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww=="
+        }
       }
     },
     "seek-bzip": {
@@ -10843,7 +10898,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -11714,9 +11770,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
-      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel": {
       "version": "0.0.6",
@@ -12009,7 +12065,8 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -12081,6 +12138,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12111,7 +12169,8 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -12128,6 +12187,7 @@
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
       "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
       "requires": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -12146,6 +12206,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,6 +154,12 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -181,6 +187,14 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -284,6 +298,14 @@
         "@commitlint/rules": "^8.3.4",
         "babel-runtime": "^6.23.0",
         "lodash": "4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@commitlint/load": {
@@ -348,6 +370,12 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -398,6 +426,14 @@
         "lodash": "4.17.15",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@commitlint/rules": {
@@ -5369,9 +5405,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash._reinterpolate": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
   "dependencies": {
+    "fs-extra": "^9.0.1",
     "global-agent": "^2.1.8",
-    "saucelabs": "^4.3.0",
+    "saucelabs": "^4.5.1",
     "webdriverio": "^6.1.9"
   },
   "license": "MIT",

--- a/src/browser-info.ts
+++ b/src/browser-info.ts
@@ -2,6 +2,11 @@ import {SauceLabsOptions} from 'saucelabs'
 import {BrowserObject} from "webdriverio";
 
 type SauceBaseOption = Pick<SauceLabsOptions, 'headless' | 'region'>
+interface Results {
+  status: string;
+  message: string;
+  screenshot: string;
+}
 
 /**
  * This interface describes a browser that has been launched with Saucelabs. This is helpful
@@ -17,8 +22,8 @@ export interface SaucelabsBrowser extends SauceBaseOption {
   /** Saucelabs access key that has been used to launch this browser. */
   accessKey: string;
 
-  /** Saucelabs driver instance to communicate with this browser. */
-  driver: BrowserObject
+  /** All test results will be stored here **/
+  results: Results[];
 }
 
 /** Type that describes the BrowserMap injection token. */

--- a/src/browser-info.ts
+++ b/src/browser-info.ts
@@ -1,4 +1,5 @@
 import {SauceLabsOptions} from 'saucelabs'
+import {BrowserObject} from "webdriverio";
 
 type SauceBaseOption = Pick<SauceLabsOptions, 'headless' | 'region'>
 
@@ -15,6 +16,9 @@ export interface SaucelabsBrowser extends SauceBaseOption {
 
   /** Saucelabs access key that has been used to launch this browser. */
   accessKey: string;
+
+  /** Saucelabs driver instance to communicate with this browser. */
+  driver: BrowserObject
 }
 
 /** Type that describes the BrowserMap injection token. */

--- a/src/browser-info.ts
+++ b/src/browser-info.ts
@@ -1,7 +1,7 @@
 import {SauceLabsOptions} from 'saucelabs'
-import {BrowserObject} from "webdriverio";
 
 type SauceBaseOption = Pick<SauceLabsOptions, 'headless' | 'region'>
+
 interface Results {
   status: string;
   message: string;

--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -70,9 +70,9 @@ export function SaucelabsLauncher(args,
     try {
       // Wait until the vm is destroyed and the assets are stored
       await waitUntil({
-        condition: async () => {
+        condition: () => {
           log.info(`Check if 'log.json' for browser '${browserName}' has already been stored.`);
-          await api.downloadJobAsset(sessionId, 'log.json');
+          return api.downloadJobAsset(sessionId, 'log.json');
         },
         maxRetries: 25,
       });

--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -16,114 +16,114 @@ export function SaucelabsLauncher(args,
                                   captureTimeoutLauncherDecorator,
                                   retryLauncherDecorator) {
 
-    // Apply base class mixins. This would be nice to have typed, but this is a low-priority now.
-    baseLauncherDecorator(this);
-    captureTimeoutLauncherDecorator(this);
-    retryLauncherDecorator(this);
+  // Apply base class mixins. This would be nice to have typed, but this is a low-priority now.
+  baseLauncherDecorator(this);
+  captureTimeoutLauncherDecorator(this);
+  retryLauncherDecorator(this);
 
-    // initiate driver with null to not close the tunnel too early
-    connectedDrivers.set(this.id, null)
+  // initiate driver with null to not close the tunnel too early
+  connectedDrivers.set(this.id, null)
 
-    const log = logger.create('SaucelabsLauncher');
-    const {
-        startConnect,
-        sauceConnectOptions,
-        seleniumCapabilities,
-        browserName
-    } = processConfig(config, args);
+  const log = logger.create('SaucelabsLauncher');
+  const {
+    startConnect,
+    sauceConnectOptions,
+    seleniumCapabilities,
+    browserName
+  } = processConfig(config, args);
 
-    // Setup Browser name that will be printed out by Karma.
-    this.name = browserName + ' on SauceLabs';
+  // Setup Browser name that will be printed out by Karma.
+  this.name = browserName + ' on SauceLabs';
 
-    // Listen for the start event from Karma. I know, the API is a bit different to how you
-    // would expect, but we need to follow this approach unless we want to spend more work
-    // improving type safety.
-    this.on('start', async (pageUrl: string) => {
-        if (startConnect) {
-            try {
-                // In case the "startConnect" option has been enabled, establish a tunnel and wait
-                // for it being ready. In case a tunnel is already active, this will just continue
-                // without establishing a new one.
-                await sauceConnect.establishTunnel(seleniumCapabilities, sauceConnectOptions);
-            } catch (error) {
-                log.error(error);
+  // Listen for the start event from Karma. I know, the API is a bit different to how you
+  // would expect, but we need to follow this approach unless we want to spend more work
+  // improving type safety.
+  this.on('start', async (pageUrl: string) => {
+    if (startConnect) {
+      try {
+        // In case the "startConnect" option has been enabled, establish a tunnel and wait
+        // for it being ready. In case a tunnel is already active, this will just continue
+        // without establishing a new one.
+        await sauceConnect.establishTunnel(seleniumCapabilities, sauceConnectOptions);
+      } catch (error) {
+        log.error(error);
 
-                this._done('failure');
-                return;
-            }
-        }
+        this._done('failure');
+        return;
+      }
+    }
 
-        try {
-            // See the following link for public API of the selenium server.
-            // https://wiki.saucelabs.com/display/DOCS/Instant+Selenium+Node.js+Tests
-            const driver = await remote(seleniumCapabilities);
+    try {
+      // See the following link for public API of the selenium server.
+      // https://wiki.saucelabs.com/display/DOCS/Instant+Selenium+Node.js+Tests
+      const driver = await remote(seleniumCapabilities);
 
-            // Keep track of all connected drivers because it's possible that there are multiple
-            // driver instances (e.g. when running with concurrency)
-            connectedDrivers.set(this.id, driver);
+      // Keep track of all connected drivers because it's possible that there are multiple
+      // driver instances (e.g. when running with concurrency)
+      connectedDrivers.set(this.id, driver);
 
-            const sessionId = driver.sessionId
+      const sessionId = driver.sessionId
 
-            log.info('%s session at https://saucelabs.com/tests/%s', browserName, sessionId);
-            log.debug('Opening "%s" on the selenium client', pageUrl);
+      log.info('%s session at https://saucelabs.com/tests/%s', browserName, sessionId);
+      log.debug('Opening "%s" on the selenium client', pageUrl);
 
-            // Store the information about the current session in the browserMap. This is necessary
-            // because otherwise the Saucelabs reporter is not able to report results.
-            browserMap.set(this.id, {
-                sessionId,
-                username: seleniumCapabilities.user,
-                accessKey: seleniumCapabilities.key,
-                region: seleniumCapabilities.region,
-                headless: seleniumCapabilities.headless,
-                results:[],
-            });
+      // Store the information about the current session in the browserMap. This is necessary
+      // because otherwise the Saucelabs reporter is not able to report results.
+      browserMap.set(this.id, {
+        sessionId,
+        username: seleniumCapabilities.user,
+        accessKey: seleniumCapabilities.key,
+        region: seleniumCapabilities.region,
+        headless: seleniumCapabilities.headless,
+        results: [],
+      });
 
-            await driver.url(pageUrl);
-        } catch (e) {
-            log.error(e);
+      await driver.url(pageUrl);
+    } catch (e) {
+      log.error(e);
 
-            // Notify karma about the failure.
-            this._done('failure');
-        }
-    });
+      // Notify karma about the failure.
+      this._done('failure');
+    }
+  });
 
-    this.on('kill', async (done: () => void) => {
-        try {
-            const driver = connectedDrivers.get(this.id);
-            const {sessionId} = driver;
-            await driver.deleteSession();
+  this.on('kill', async (done: () => void) => {
+    try {
+      const driver = connectedDrivers.get(this.id);
+      const {sessionId} = driver;
+      await driver.deleteSession();
 
-            const browserData = browserMap.get(this.id);
-            const api = new SauceLabs({
-                user: browserData.username,
-                key: browserData.accessKey,
-                region: browserData.region,
-            });
+      const browserData = browserMap.get(this.id);
+      const api = new SauceLabs({
+        user: browserData.username,
+        key: browserData.accessKey,
+        region: browserData.region,
+      });
 
-            // Wait until the vm is destroyed and the assets are stored
-            await new Promise(resolve => setTimeout(() => resolve(), 5000));
-            // Create a tmp dir
-            mkdirSync(sessionId);
-            writeFileSync(`${sessionId}/log.json`, JSON.stringify(browserData.results, null, 2));
-            // Update the log assets
-            // @ts-ignore
-            await api.uploadJobAssets(
-                sessionId,
-                { files: [`${sessionId}/log.json`] },
-            );
-            // remove the temporary folder
-            removeSync(sessionId);
+      // Wait until the vm is destroyed and the assets are stored
+      await new Promise(resolve => setTimeout(() => resolve(), 5000));
+      // Create a tmp dir
+      mkdirSync(sessionId);
+      writeFileSync(`${sessionId}/log.json`, JSON.stringify(browserData.results, null, 2));
+      // Update the log assets
+      // @ts-ignore
+      await api.uploadJobAssets(
+        sessionId,
+        {files: [`${sessionId}/log.json`]},
+      );
+      // remove the temporary folder
+      removeSync(sessionId);
 
-        } catch (e) {
-            // We need to ignore the exception here because we want to make sure that Karma is still
-            // able to retry connecting if Saucelabs itself terminated the session (and not Karma)
-            // For example if the "idleTimeout" is exceeded and Saucelabs errored the session. See:
-            // https://wiki.saucelabs.com/display/DOCS/Test+Didn%27t+See+a+New+Command+for+90+Seconds
-            log.error('Could not quit the Saucelabs selenium connection. Failure message:');
-            log.error(e);
-        }
+    } catch (e) {
+      // We need to ignore the exception here because we want to make sure that Karma is still
+      // able to retry connecting if Saucelabs itself terminated the session (and not Karma)
+      // For example if the "idleTimeout" is exceeded and Saucelabs errored the session. See:
+      // https://wiki.saucelabs.com/display/DOCS/Test+Didn%27t+See+a+New+Command+for+90+Seconds
+      log.error('Could not quit the Saucelabs selenium connection. Failure message:');
+      log.error(e);
+    }
 
-        connectedDrivers.delete(this.id)
-        return process.nextTick(done);
-    })
+    connectedDrivers.delete(this.id)
+    return process.nextTick(done);
+  })
 }

--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -14,90 +14,91 @@ export function SaucelabsLauncher(args,
                                   captureTimeoutLauncherDecorator,
                                   retryLauncherDecorator) {
 
-  // Apply base class mixins. This would be nice to have typed, but this is a low-priority now.
-  baseLauncherDecorator(this);
-  captureTimeoutLauncherDecorator(this);
-  retryLauncherDecorator(this);
+    // Apply base class mixins. This would be nice to have typed, but this is a low-priority now.
+    baseLauncherDecorator(this);
+    captureTimeoutLauncherDecorator(this);
+    retryLauncherDecorator(this);
 
-  // initiate driver with null to not close the tunnel too early
-  connectedDrivers.set(this.id, null)
+    // initiate driver with null to not close the tunnel too early
+    connectedDrivers.set(this.id, null)
 
-  const log = logger.create('SaucelabsLauncher');
-  const {
-    startConnect,
-    sauceConnectOptions,
-    seleniumCapabilities,
-    browserName
-  } = processConfig(config, args);
+    const log = logger.create('SaucelabsLauncher');
+    const {
+        startConnect,
+        sauceConnectOptions,
+        seleniumCapabilities,
+        browserName
+    } = processConfig(config, args);
 
-  // Setup Browser name that will be printed out by Karma.
-  this.name = browserName + ' on SauceLabs';
+    // Setup Browser name that will be printed out by Karma.
+    this.name = browserName + ' on SauceLabs';
 
-  // Listen for the start event from Karma. I know, the API is a bit different to how you
-  // would expect, but we need to follow this approach unless we want to spend more work
-  // improving type safety.
-  this.on('start', async (pageUrl: string) => {
-    if (startConnect) {
-      try {
-        // In case the "startConnect" option has been enabled, establish a tunnel and wait
-        // for it being ready. In case a tunnel is already active, this will just continue
-        // without establishing a new one.
-        await sauceConnect.establishTunnel(seleniumCapabilities, sauceConnectOptions);
-      } catch (error) {
-        log.error(error);
+    // Listen for the start event from Karma. I know, the API is a bit different to how you
+    // would expect, but we need to follow this approach unless we want to spend more work
+    // improving type safety.
+    this.on('start', async (pageUrl: string) => {
+        if (startConnect) {
+            try {
+                // In case the "startConnect" option has been enabled, establish a tunnel and wait
+                // for it being ready. In case a tunnel is already active, this will just continue
+                // without establishing a new one.
+                await sauceConnect.establishTunnel(seleniumCapabilities, sauceConnectOptions);
+            } catch (error) {
+                log.error(error);
 
-        this._done('failure');
-        return;
-      }
-    }
+                this._done('failure');
+                return;
+            }
+        }
 
-    try {
-      // See the following link for public API of the selenium server.
-      // https://wiki.saucelabs.com/display/DOCS/Instant+Selenium+Node.js+Tests
-      const driver = await remote(seleniumCapabilities);
+        try {
+            // See the following link for public API of the selenium server.
+            // https://wiki.saucelabs.com/display/DOCS/Instant+Selenium+Node.js+Tests
+            const driver = await remote(seleniumCapabilities);
 
-      // Keep track of all connected drivers because it's possible that there are multiple
-      // driver instances (e.g. when running with concurrency)
-      connectedDrivers.set(this.id, driver);
+            // Keep track of all connected drivers because it's possible that there are multiple
+            // driver instances (e.g. when running with concurrency)
+            connectedDrivers.set(this.id, driver);
 
-      const sessionId = driver.sessionId
+            const sessionId = driver.sessionId
 
-      log.info('%s session at https://saucelabs.com/tests/%s', browserName, sessionId);
-      log.debug('Opening "%s" on the selenium client', pageUrl);
+            log.info('%s session at https://saucelabs.com/tests/%s', browserName, sessionId);
+            log.debug('Opening "%s" on the selenium client', pageUrl);
 
-      // Store the information about the current session in the browserMap. This is necessary
-      // because otherwise the Saucelabs reporter is not able to report results.
-      browserMap.set(this.id, {
-        sessionId,
-        username: seleniumCapabilities.user,
-        accessKey: seleniumCapabilities.key,
-        region: seleniumCapabilities.region,
-        headless: seleniumCapabilities.headless
-      });
+            // Store the information about the current session in the browserMap. This is necessary
+            // because otherwise the Saucelabs reporter is not able to report results.
+            browserMap.set(this.id, {
+                sessionId,
+                username: seleniumCapabilities.user,
+                accessKey: seleniumCapabilities.key,
+                region: seleniumCapabilities.region,
+                headless: seleniumCapabilities.headless,
+                driver,
+            });
 
-      await driver.url(pageUrl);
-    } catch (e) {
-      log.error(e);
+            await driver.url(pageUrl);
+        } catch (e) {
+            log.error(e);
 
-      // Notify karma about the failure.
-      this._done('failure');
-    }
-  });
+            // Notify karma about the failure.
+            this._done('failure');
+        }
+    });
 
-  this.on('kill', async (done: () => void) => {
-    try {
-      const driver = connectedDrivers.get(this.id);
-      await driver.deleteSession();
-    } catch (e) {
-      // We need to ignore the exception here because we want to make sure that Karma is still
-      // able to retry connecting if Saucelabs itself terminated the session (and not Karma)
-      // For example if the "idleTimeout" is exceeded and Saucelabs errored the session. See:
-      // https://wiki.saucelabs.com/display/DOCS/Test+Didn%27t+See+a+New+Command+for+90+Seconds
-      log.error('Could not quit the Saucelabs selenium connection. Failure message:');
-      log.error(e);
-    }
+    this.on('kill', async (done: () => void) => {
+        try {
+            const driver = connectedDrivers.get(this.id);
+            await driver.deleteSession();
+        } catch (e) {
+            // We need to ignore the exception here because we want to make sure that Karma is still
+            // able to retry connecting if Saucelabs itself terminated the session (and not Karma)
+            // For example if the "idleTimeout" is exceeded and Saucelabs errored the session. See:
+            // https://wiki.saucelabs.com/display/DOCS/Test+Didn%27t+See+a+New+Command+for+90+Seconds
+            log.error('Could not quit the Saucelabs selenium connection. Failure message:');
+            log.error(e);
+        }
 
-    connectedDrivers.delete(this.id)
-    return process.nextTick(done);
-  })
+        connectedDrivers.delete(this.id)
+        return process.nextTick(done);
+    })
 }

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -27,13 +27,20 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
   // This fires when a single test is executed and will update the run in sauce labs with an annotation
   // of the test including the status of the test
   this.onSpecComplete = function(browser, result) {
-    const driver = browserMap.get(browser.id).driver
     const status = result.success ? '✅' : '❌'
 
-    pendingUpdates.push(driver.execute(`sauce:context=${status}: ${result.fullName}`))
+    browserMap.get(browser.id).results.push({
+      status: 'info',
+      message: `${status} ${result.fullName}`,
+      screenshot: null
+    })
 
     if(!result.success && result.log.length > 0){
-      pendingUpdates.push(driver.execute(`sauce:context=${result.log[0]}`))
+      browserMap.get(browser.id).results.push({
+        status: 'info',
+        message: `${result.log[0]}`,
+        screenshot: null
+      })
     }
   }
 

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -9,6 +9,19 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
   const log = logger.create('reporter.sauce');
   let pendingUpdates: Promise<Job>[] = [];
 
+  // This fires when a single test is executed and will update the run in sauce labs with an annotation
+  // of the test including the status of the test
+  this.onSpecComplete = function(browser, result) {
+    const driver = browserMap.get(browser.id).driver
+    const status = result.success ? '✅' : '❌'
+
+    pendingUpdates.push(driver.execute(`sauce:context=${status}: ${result.fullName}`))
+
+    if(!result.success && result.log.length > 0){
+      pendingUpdates.push(driver.execute(`sauce:context=${result.log[0]}`))
+    }
+  }
+
   // This fires whenever any browser completes. This is when we want to report results
   // to the Saucelabs API, so that people can create coverage banners for their project.
   this.onBrowserComplete = function (browser) {

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -29,8 +29,6 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
   this.onSpecComplete = function (browser, result) {
     const status = result.success ? '✅' : '❌'
 
-    console.log('onSpecComplete result = ', result)
-
     browserMap.get(browser.id).results.push({
       status: 'info',
       message: `${status} ${result.fullName}`,

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -1,5 +1,5 @@
 import {BrowserMap} from "../browser-info";
-import SaucelabsAPI, {Job} from 'saucelabs';
+import SauceLabsAPI, {Job} from 'saucelabs';
 
 const REGION_MAPPING = {
   'us': '', // default endpoint
@@ -28,6 +28,8 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
   // of the test including the status of the test
   this.onSpecComplete = function (browser, result) {
     const status = result.success ? '✅' : '❌'
+
+    console.log('onSpecComplete result = ', result)
 
     browserMap.get(browser.id).results.push({
       status: 'info',
@@ -67,7 +69,7 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
     }
 
     const {sessionId} = browserData;
-    const api = new SaucelabsAPI({
+    const api = new SauceLabsAPI({
       user: browserData.username,
       key: browserData.accessKey,
       region: browserData.region,

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -1,6 +1,21 @@
 import {BrowserMap} from "../browser-info";
 import SaucelabsAPI, {Job} from 'saucelabs';
 
+const REGION_MAPPING = {
+  'us': '', // default endpoint
+  'eu': 'eu-central-1.',
+};
+
+/**
+ * Get the Sauce Labs endpoint
+ * @param region
+ */
+function getSauceEndpoint (region) {
+  const shortRegion = REGION_MAPPING[region] ? region : 'us'
+
+  return `https://app.${REGION_MAPPING[shortRegion]}saucelabs.com/tests/`
+}
+
 /**
  * Karma browser reported that updates corresponding Saucelabs jobs whenever a given
  * browser finishes.
@@ -60,6 +75,8 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
       passed: hasPassed,
       'custom-data': result
     }));
+
+    log.info(`Check out job at ${getSauceEndpoint(browserData.region)}${sessionId}`)
   };
 
   // Whenever this method is being called, we just need to wait for all API calls to finish,

--- a/src/reporter/reporter.ts
+++ b/src/reporter/reporter.ts
@@ -10,7 +10,7 @@ const REGION_MAPPING = {
  * Get the Sauce Labs endpoint
  * @param region
  */
-function getSauceEndpoint (region) {
+function getSauceEndpoint(region) {
   const shortRegion = REGION_MAPPING[region] ? region : 'us'
 
   return `https://app.${REGION_MAPPING[shortRegion]}saucelabs.com/tests/`
@@ -26,7 +26,7 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
 
   // This fires when a single test is executed and will update the run in sauce labs with an annotation
   // of the test including the status of the test
-  this.onSpecComplete = function(browser, result) {
+  this.onSpecComplete = function (browser, result) {
     const status = result.success ? '✅' : '❌'
 
     browserMap.get(browser.id).results.push({
@@ -35,7 +35,7 @@ export function SaucelabsReporter(logger, browserMap: BrowserMap) {
       screenshot: null
     })
 
-    if(!result.success && result.log.length > 0){
+    if (!result.success && result.log.length > 0) {
       browserMap.get(browser.id).results.push({
         status: 'info',
         message: `${result.log[0]}`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+export async function waitUntil({condition, retries = 0, maxRetries = 50, interval = 200}) {
+  try {
+    return await condition()
+  } catch (error) {
+    if (retries >= maxRetries) {
+      throw error;
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, interval))
+
+  return waitUntil({condition, retries: retries++, maxRetries, interval})
+}


### PR DESCRIPTION
This PR will add:
- replace the current Sauce Labs logs, which only contains a driver start and stop, with a new log that contains all the tests have been executed in this session
- execution urls to the logs so users can easily open the Sauce Labs execution

**Current reporting:**
![image](https://user-images.githubusercontent.com/11979740/97112555-3526f700-16e5-11eb-8a45-a7d3af14863d.png)


**New success example:**
![image](https://user-images.githubusercontent.com/11979740/97467172-36099400-1944-11eb-9426-f885223b6f42.png)

**New failure example:**
![image](https://user-images.githubusercontent.com/11979740/97467112-25f1b480-1944-11eb-9bbc-5c3facb47a02.png)

**Logs with execution url:**
![image](https://user-images.githubusercontent.com/11979740/97113179-e3806b80-16e8-11eb-8c15-e260d4f52341.png)
