### PR TITLE
feat: add heartbeat to keep session alive every 60 seconds

### DIFF
--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -39,7 +39,9 @@ export function SaucelabsLauncher(args,
     const driver = connectedDrivers.get(this.id);
 
     pendingHeartBeat = setTimeout( async () => {
-      if(driver) {
+      if (!driver) {
+        return
+      }
         try {
           await driver.getTitle();
           log.debug('Heartbeat to Sauce Labs (%s) - fetching title', browserName)

--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -35,7 +35,7 @@ export function SaucelabsLauncher(args,
 
   let pendingHeartBeat;
   // Heartbeat function to keep alive sessions on Sauce Labs via WebDriver calls
-  const heartbeat = ()=> {
+  const heartbeat = () => {
     const driver = connectedDrivers.get(this.id);
 
     pendingHeartBeat = setTimeout( async () => {

--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -38,10 +38,10 @@ export function SaucelabsLauncher(args,
   const heartbeat = () => {
     const driver = connectedDrivers.get(this.id);
 
-    pendingHeartBeat = setTimeout( async () => {
-      if (!driver) {
-        return
-      }
+    pendingHeartBeat = setTimeout(async () => {
+        if (!driver) {
+          return
+        }
         try {
           await driver.getTitle();
           log.debug('Heartbeat to Sauce Labs (%s) - fetching title', browserName)
@@ -50,9 +50,10 @@ export function SaucelabsLauncher(args,
           // Do nothing, just clear the timeout
           clearTimeout(pendingHeartBeat)
         }
-      }
-      return;
-    }, 60000);
+        return;
+      },
+      60000,
+    );
   }
 
   // Listen for the start event from Karma. I know, the API is a bit different to how you


### PR DESCRIPTION
This PR re-implements the heartbeat which was reverted due to this issue https://github.com/karma-runner/karma-sauce-launcher/issues/198