### PR TITLE
fix: Call launcher done callback

### DIFF
--- a/src/launcher/launcher.ts
+++ b/src/launcher/launcher.ts
@@ -170,6 +170,8 @@ export function SaucelabsLauncher(args,
     }
 
     connectedDrivers.delete(this.id)
+
+    this._done();
     return process.nextTick(done);
   })
 }


### PR DESCRIPTION
This PR is based on https://github.com/karma-runner/karma-sauce-launcher/pull/160 and will fix https://github.com/karma-runner/karma-sauce-launcher/issues/159. 

It will fix the issue that the launcher didn't call the done callback when the concurrency configured in the Karma config was lower than the amount of instances that you want to run