### PR TITLE
fix: fix automatic capabilities conversion from JWP to W3C

### DIFF
--- a/src/process-config.ts
+++ b/src/process-config.ts
@@ -21,7 +21,9 @@ export function processConfig(config: any = {}, args: any = {}) {
   }
 
   // Browser name that will be printed out by Karma.
-  const browserName = `${args.browserName} ${args.browserVersion || args.version || ''} ${args.platformName || args.platform || ''}`;
+  const browserName =
+    `${args.browserName} ${args.browserVersion || args.version || ''} ` +
+    `${args.platformName || args.platform || ''} ${args['appium:platformVersion'] || ''}`.trim();
 
   // In case "startConnect" is enabled, and no tunnel identifier has been specified, we just
   // generate one randomly. This makes it possible for developers to use "startConnect" with

--- a/src/process-config.ts
+++ b/src/process-config.ts
@@ -57,17 +57,19 @@ export function processConfig(config: any = {}, args: any = {}) {
   };
 
   // transform JWP capabilities into W3C capabilities for backward compatibility
-  if (isW3C(args)) {
+  if (!isW3C(args)) {
     args.browserVersion = args.browserVersion || args.version || 'latest'
     args.platformName = args.platformName || args.platform || 'Windows 10'
-    args['sauce:options'] = {...capabilitiesFromConfig, ...(args['sauce:options'] || {})}
 
     // delete JWP capabilities
     delete args.version
     delete args.platform
-  } else {
-    args = {...args, ...capabilitiesFromConfig}
   }
+
+  // Move capabilities from config into `sauce:options`. This is necessary for W3C.
+  // See: https://docs.saucelabs.com/dev/w3c-webdriver-capabilities/index.html#use-sauceoptions
+  args['sauce:options'] = {...capabilitiesFromConfig, ...(args['sauce:options'] || {})}
+
   // Not needed
   delete args.base
 


### PR DESCRIPTION
A couple of fixes mainly related to the automatic conversion of capabilities from the legacy JWP format to the new W3C.
See the individual commit messages for details.
